### PR TITLE
Remove xwinfo depency

### DIFF
--- a/bspwm-scripts/PKGBUILD
+++ b/bspwm-scripts/PKGBUILD
@@ -14,7 +14,6 @@ depends=('dmenu-manjaro'
 	'wmctrl'
 	'wmutils'
 	'xtitle'
-	'xwinfo'
 	'xdo')
 makedepends=('git')
 source=("git://github.com/Chrysostomus/$pkgname")


### PR DESCRIPTION
Its function has been replaced with wmutils, and it is no longer needed.