### PR TITLE
Multihead support for limepanel

### DIFF
--- a/lemonpanel/PKGBUILD
+++ b/lemonpanel/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Chrysostomus
 
 pkgname=lemonpanel
-_ver=0.9
+_ver=0.10
 pkgver=0.9.r123.e72d932
 pkgrel=1
 pkgdesc="Panel script for bspwm using patched dmenu and lemonbar"

--- a/limepanel/PKGBUILD
+++ b/limepanel/PKGBUILD
@@ -2,7 +2,7 @@
 # Maintainer: Chrysostomus
 
 pkgname=limepanel
-_ver=0.9
+_ver=0.10
 pkgver=0.9.r45.fd33b61
 pkgrel=1
 pkgdesc="Panel script for bspwm using patched dmenu and lemonbar"


### PR DESCRIPTION
Version bump in {lemon,lime}panel is required for added multihead support in limepanel.