### PR TITLE
Split packages and new package

### DIFF
--- a/bmenu/PKGBUILD
+++ b/bmenu/PKGBUILD
@@ -12,7 +12,8 @@ depends=('bash'
 	'mhwd-tui'
 	'brandr'
 	'awk'
-	'sed')
+	'sed'
+	'elinks')
 makedepends=('git')
 source=("git://github.com/Chrysostomus/$pkgname")
 md5sums=('SKIP')

--- a/bmenu/PKGBUILD
+++ b/bmenu/PKGBUILD
@@ -1,0 +1,25 @@
+# Maintainer: Chrysostomus @forum.manjaro.org
+
+pkgname=bmenu
+pkgver=0.1
+pkgrel=1
+pkgdesc="Simple system menu for commandline"
+arch=(any)
+url="https://github.com/Chrysostomus/$pkgname"
+license=MIT
+depends=('bash'
+	'pacli'
+	'mhwd-tui'
+	'brandr'
+	'awk'
+	'sed')
+makedepends=('git')
+source=("git://github.com/Chrysostomus/$pkgname")
+md5sums=('SKIP')
+
+package () {
+	cd "$srcdir"
+	install -dm755 $pkgdir/usr/bin
+	cp -r $srcdir/$pkgname/bin $pkgdir/usr
+	chmod a+x $pkgdir/usr/bin/*
+}

--- a/brandr/PKGBUILD
+++ b/brandr/PKGBUILD
@@ -1,0 +1,21 @@
+# Maintainer: Chrysostomus @forum.manjaro.org
+
+pkgname=brandr
+pkgver=0.1
+pkgrel=1
+pkgdesc="An interactive xrandr interface using bash"
+arch=(any)
+url="https://github.com/Chrysostomus/$pkgname"
+license=MIT
+depends=('awk'
+	'bash'
+	'xrandr')
+optdepends=('pacli: package management menu item')
+makedepends=('git')
+source=("git://github.com/Chrysostomus/$pkgname")
+md5sums=('SKIP')
+
+package () {
+	cd "$srcdir"
+        install -Dm755 "$srcdir/$pkgname/brandr" "$pkgdir/usr/bin/brandr"
+}

--- a/lemonpanel/PKGBUILD
+++ b/lemonpanel/PKGBUILD
@@ -23,7 +23,8 @@ depends=('dmenu-manjaro'
 	'ttf-ionicons'
 	'zenity'
 	'xdg-utils'
-	'rootmenu')
+	'rootmenu'
+        'update-notifier')
 makedepends=git
 source="git://github.com/Chrysostomus/lemonpanel"
 md5sums=('SKIP')

--- a/mhwd-tui/PKGBUILD
+++ b/mhwd-tui/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Chrysostomus @forum.manjaro.org
 
 pkgname=mhwd-tui
-pkgver=0.1
+pkgver=0.2
 pkgrel=1
 pkgdesc="An interactive mhwd interface using bash"
 arch=(any)

--- a/pacli/PKGBUILD
+++ b/pacli/PKGBUILD
@@ -12,7 +12,8 @@ depends=('pmenu'
 	'yaourt'
 	'downgrade'
 	'sudo'
-	'bash')
+	'bash'
+        'update-notifier')
 makedepends=('git')
 source=("git://github.com/Manjaro-Pek/$pkgname")
 md5sums=('SKIP')

--- a/update-notifier/PKGBUILD
+++ b/update-notifier/PKGBUILD
@@ -1,0 +1,20 @@
+# Maintainer: Chrysostomus @forum.manjaro.org
+
+pkgname=update-notifier
+pkgver=0.1
+pkgrel=1
+pkgdesc="A simple pacman update notifier"
+arch=(any)
+url="https://github.com/Chrysostomus/$pkgname"
+license=MIT
+depends=('pacman'
+	'awk'
+        'yaourt')
+makedepends=('git')
+source=("git://github.com/Chrysostomus/$pkgname")
+md5sums=('SKIP')
+
+package () {
+	cd "$srcdir"
+        install -Dm755 "$srcdir/$pkgname/mhwd-tui" "$pkgdir/usr/bin/mhwd-tui"
+}


### PR DESCRIPTION
Make update-notifier separate package from lemonpanel so it can be shared by lemonpanel and pacli. Add bmenu, a bash based systemmenu to control various aspects of system and desktop. Add brandr, bash based interactive xrandr interface.