### PR TITLE
Update PKGBUILD

### DIFF
--- a/update-notifier/PKGBUILD
+++ b/update-notifier/PKGBUILD
@@ -16,5 +16,5 @@ md5sums=('SKIP')
 
 package () {
 	cd "$srcdir"
-        install -Dm755 "$srcdir/$pkgname/mhwd-tui" "$pkgdir/usr/bin/mhwd-tui"
+        install -Dm755 "$srcdir/$pkgname/update-notifier" "$pkgdir/usr/bin/nodate-notifier"
 }


### PR DESCRIPTION
Fixed offending PKGBUILD. The install command was wrong because of leftovers of its source. I had just copied build from another package and changed relevant data, but forgot the last bit.