### PR TITLE
Hard fix for unload nvidia_nomodeset module for bumblebee

### DIFF
--- a/bumblebee/PKGBUILD
+++ b/bumblebee/PKGBUILD
@@ -4,7 +4,7 @@
 
 pkgname=bumblebee
 pkgver=3.2.1
-pkgrel=6
+pkgrel=7
 pkgdesc="NVIDIA Optimus support for Linux through Primus/VirtualGL"
 arch=('i686' 'x86_64')
 depends=('primus' 'glib2' 'mesa-libgl')
@@ -24,20 +24,18 @@ license=("GPL3")
 backup=('etc/bumblebee/bumblebee.conf' 
         'etc/bumblebee/xorg.conf.nouveau' 
         'etc/bumblebee/xorg.conf.nvidia')
-source=("http://www.bumblebee-project.org/${pkgname}-${pkgver}.tar.gz"
-        'bumblebee-3.2.1-modprobe.patch::https://github.com/Bumblebee-Project/Bumblebee/commit/1ada79fe5916961fc4e4917f8c63bb184908d986.patch'
-        "bumblebee-hexadecimal.patch::https://github.com/Bumblebee-Project/Bumblebee/commit/2073f8537412aa47755eb6f3f22a114403e5285b.patch")
+source=("http://www.bumblebee-project.org/${pkgname}-${pkgver}.tar.gz" "bb_hexadicimal_bug699.patch")
 md5sums=('30974e677bb13e8a3825fd6f3e7d3b24'
-         '7c19d51712896b2fc2d349fc7569f8cf'
-         'd0a7d504a717e34b05fb4bc9ee68f881')
-
-prepare() {
-    cd "${srcdir}/${pkgname}-${pkgver}"
-    patch -p1 -i "${srcdir}/bumblebee-3.2.1-modprobe.patch"
-    patch -p1 -i "${srcdir}/bumblebee-hexadecimal.patch"
-}
+         '09d3c01ad86d92e51ec14a67f4a92c2a')
 
 build() {
+    # Hard workaround for unload nvidia_nomodeset module.
+    # Reference: https://github.com/arafey/Bumblebee/commit/5636b24fa86a005a5d2e30bd794516db13ccba56
+    # https://github.com/Bumblebee-Project/Bumblebee/issues/699
+    # Merged with: https://github.com/Bumblebee-Project/Bumblebee/commit/2073f8537412aa47755eb6f3f22a114403e5285b
+    # in one patch file
+    patch -p1 -i ${srcdir}/bb_hexadicimal_bug699.patch
+    
     cd "${srcdir}/${pkgname}-${pkgver}"
 
     ./configure \

--- a/bumblebee/bb_hexadicimal_bug699.patch
+++ b/bumblebee/bb_hexadicimal_bug699.patch
@@ -1,0 +1,31 @@
+# Hard workaround for unload nvidia_nomodeset module.
+# Reference: https://github.com/arafey/Bumblebee/commit/5636b24fa86a005a5d2e30bd794516db13ccba56
+# https://github.com/Bumblebee-Project/Bumblebee/issues/699
+# Merged with: https://github.com/Bumblebee-Project/Bumblebee/commit/2073f8537412aa47755eb6f3f22a114403e5285b
+
+diff --git a/bumblebee-3.2.1/src/bbsecondary.c b/bumblebee-3.2.1/src/bbsecondary.c
+--- a/bumblebee-3.2.1/src/bbsecondary.c
++++ b/bumblebee-3.2.1/src/bbsecondary.c
+@@ -138,7 +138,7 @@
+   if (!bb_is_running(bb_status.x_pid)) {
+     char pci_id[12];
+     static char *x_conf_file;
+-    snprintf(pci_id, 12, "PCI:%02x:%02x:%o", pci_bus_id_discrete->bus,
++    snprintf(pci_id, 12, "PCI:%02d:%02d:%o", pci_bus_id_discrete->bus,
+             pci_bus_id_discrete->slot, pci_bus_id_discrete->func);
+     if (!x_conf_file) {
+       x_conf_file = xorg_path_w_driver(bb_config.x_conf_file, bb_config.driver);
+diff --git a/bumblebee-3.2.1/src/module.c b/bumblebee-3.2.1/src/module.c
+--- a/bumblebee-3.2.1/src/module.c
++++ b/bumblebee-3.2.1/src/module.c
+@@ -96,7 +96,9 @@
+     int retries = 30;
+     bb_log(LOG_INFO, "Unloading %s driver\n", driver);
+     char *mod_argv[] = {
+-      "rmmod",
++      "modprobe",
++      "-r",
++      "nvidia_modeset",
+       driver,
+       NULL
+     };

--- a/qtcurve/PKGBUILD
+++ b/qtcurve/PKGBUILD
@@ -13,7 +13,7 @@ arch=('i686' 'x86_64')
 url="https://github.com/QtCurve/${pkgbase}"
 license=('LGPL')
 groups=('qtcurve')
-makedepends=(cmake automoc4 git gtk2 qt4 qt5-{svg,x11extras})
+makedepends=(cmake automoc4 git gtk2 qt4 qt5-{svg,x11extras} kdebase-runtime)
 source=("${pkgbase}::git://anongit.kde.org/${pkgbase}.git")
 md5sums=('SKIP')
 


### PR DESCRIPTION
Hard workaround for unload nvidia_nomodeset module.
Reference: https://github.com/arafey/Bumblebee/commit/5636b24fa86a005a5d2e30bd794516db13ccba56
https://github.com/Bumblebee-Project/Bumblebee/issues/699
Merged with: https://github.com/Bumblebee-Project/Bumblebee/commit/2073f8537412aa47755eb6f3f22a114403e5285b
 in one patch file
working like a charm for me: https://pastebin.com/raw.php?i=MbWrYV0y
@philmmanjaro

Regards
