### PR TITLE
[bumblebee] Fix nvidia_uvm unloading

### DIFF
--- a/bumblebee/PKGBUILD
+++ b/bumblebee/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=bumblebee
 pkgver=3.2.1
-pkgrel=10
+pkgrel=11
 pkgdesc="NVIDIA Optimus support for Linux through Primus/VirtualGL"
 install=bumblebee.install
 arch=('i686' 'x86_64')
@@ -27,13 +27,18 @@ backup=('etc/bumblebee/bumblebee.conf'
         'etc/bumblebee/xorg.conf.nouveau' 
         'etc/bumblebee/xorg.conf.nvidia')
 source=("http://www.bumblebee-project.org/${pkgname}-${pkgver}.tar.gz"
-        "bb_hexadicimal_bug699.patch"
-        "bb_nvidia_modeset-detection_bug699.patch")
-md5sums=('30974e677bb13e8a3825fd6f3e7d3b24'
-         '09d3c01ad86d92e51ec14a67f4a92c2a'
-         '92c5aa0bfa39e41b0092362e555e93de')
+        "0001-bb_nvidia_modeset-detection_bug699_01.patch::https://github.com/arafey/Bumblebee/commit/5636b24fa86a005a5d2e30bd794516db13ccba56.patch"
+        "0002-bb_nvidia_modeset-detection_bug699_02.patch::https://github.com/arafey/Bumblebee/commit/09d537e8e5313cd0f2c7bf6620ca70454de8a04a.patch"
+        "0003-bb_nvidia_umv_detection_bug699.patch::https://github.com/arafey/Bumblebee/commit/dbbf20a38aa2bffb10c4e8af583b34dff6bfe721.patch"
+        "0004-bb_hexadicimal_bug573.patch::https://github.com/Bumblebee-Project/Bumblebee/commit/2073f8537412aa47755eb6f3f22a114403e5285b.patch")
+sha256sums=('1018703b07e2f607a4641249d69478ce076ae5a1e9dd6cff5694d394fa7ee30e'
+            'aff3528d17a77ff19b4e0a7a10682b8351456f11795f71ef62b315e774fb408a'
+            '70ad9b3d8e0d70a504110651c6f5f3a1b1d3c4c44eeb0fd49a4463e99124a47b'
+            '16fd522f412125b3c9b5709d78584744c70cb627e8baf8cd6025a71d278f79a6'
+            '0b7c1f4bb2e27d131c6c21fd7006d075584917ac4259bd9899e6eca99efc0ece')
 
 prepare() {
+    cd "${srcdir}/${pkgname}-${pkgver}"
     ###############################################################################################################################
     # Issue #699                                                                                                                  #
     #-----------------------------------------------------------------------------------------------------------------------------#
@@ -42,7 +47,9 @@ prepare() {
     # (this also unloads nvidia), and log errors (as before). If it doesn't detect nvidia_modeset but detects "driver",           #
     # then it will unload the detected driver just like before, except it does so using modprobe -r "driver" for consistency.     #
     # https://github.com/Bumblebee-Project/Bumblebee/issues/699                                                                   #
+    # https://github.com/arafey/Bumblebee/commit/5636b24fa86a005a5d2e30bd794516db13ccba56                                         #
     # https://github.com/arafey/Bumblebee/commit/09d537e8e5313cd0f2c7bf6620ca70454de8a04a                                         #
+    # https://github.com/arafey/Bumblebee/commit/dbbf20a38aa2bffb10c4e8af583b34dff6bfe721                                         #
     ###############################################################################################################################
     # Issue #573                                                                                                                  #
     #-----------------------------------------------------------------------------------------------------------------------------#
@@ -51,10 +58,9 @@ prepare() {
     # https://github.com/Bumblebee-Project/Bumblebee/issues/573                                                                   #
     # https://github.com/Bumblebee-Project/Bumblebee/commit/2073f8537412aa47755eb6f3f22a114403e5285b                              #
     ###############################################################################################################################
-
-    patch -p1 -i ${srcdir}/bb_hexadicimal_bug699.patch
-    cd "${srcdir}/${pkgname}-${pkgver}"
-    patch -p1 -i ${srcdir}/bb_nvidia_modeset-detection_bug699.patch
+    for p in $(ls ${srcdir}/00{01,02,03,04}*.patch); do
+    patch -Np1 -i "$p"
+    done
 }
 
 build() {    
@@ -85,4 +91,3 @@ package() {
     # Make bash_completion work
     mv -v "${pkgdir}/etc/bash_completion.d/bumblebee" "${pkgdir}/etc/bash_completion.d/optirun"
 }
-


### PR DESCRIPTION
@arafey added new patch for nvidia_uvm unloading like nvidia_modeset is.
I rewrote sources field. Now the patches are taken directly from GitHub.
Tested locally. Works correctly.
@philmmanjaro please take a look and merge.

Regards