### PR TITLE
Update PKGBUILD

### DIFF
--- a/budgie-desktop/PKGBUILD
+++ b/budgie-desktop/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Ricardo Vieira <ricardo.vieira@tecnico.ulisboa.pt>
 
 pkgname=budgie-desktop
-pkgver=10.2.1
+pkgver=10.2.2
 pkgrel=1
 pkgdesc="Simple GTK3 desktop experience"
 arch=('i686' 'x86_64')
@@ -18,7 +18,7 @@ install=budgie-desktop.install
 source=(#"$pkgname"::'git+https://github.com/solus-project/budgie-desktop.git#branch=master'
 	"$pkgname-$pkgver.tar.gz::https://github.com/solus-project/budgie-desktop/archive/v${pkgver}.tar.gz"
 	'git+https://git.gnome.org/browse/libgnome-volume-control#commit=7e5504d')
-md5sums=('5dcf6ec7f2b166a64a13ed180eb40a7e'
+md5sums=('cea64444fc14eb795c01ffa5a710e5ec'
          'SKIP')
 
 #pkgver() {


### PR DESCRIPTION
Update release to 10.2.2 , update cecksums . With this release:


    Fix many linking/portability issues on other distributions
    Fix nm-applet-likes-small-holes bug (size of x11 tray icons)
    Respect and follow screen resolution changes
    Fix background corruption on resume with NVIDIA gpus
    Fix use of colours for backgrounds
    Replace polkit-gnome dependency with our own new budgie-polkit
    Refactor much of the codebase into smallerl ibraries
    Updated translations
    Fix bug #166 (firefox becomes homeless)
    Fix uhm-is-that-youtube-i-see-through-gedit-thar transparency issue
    Consumed several pizzas