### PR TITLE
thermald post install automatics

### DIFF
--- a/thermald/PKGBUILD
+++ b/thermald/PKGBUILD
@@ -10,8 +10,7 @@ pkgdesc="The Linux Thermal Daemon program from 01.org"
 arch=('i686' 'x86_64')
 url="https://github.com/01org/${_pkgname}"
 license=('GPL2')
-makedepends=('systemd')
-depends=('dbus-glib>=0.94' 'libxml2>=2.4')
+depends=('dbus-glib>=0.94' 'libxml2>=2.4' 'systemd')
 conflicts=('thermald-git')
 backup=('etc/thermald/thermal-conf.xml')
 install="${pkgname}.install"

--- a/thermald/PKGBUILD
+++ b/thermald/PKGBUILD
@@ -10,7 +10,8 @@ pkgdesc="The Linux Thermal Daemon program from 01.org"
 arch=('i686' 'x86_64')
 url="https://github.com/01org/${_pkgname}"
 license=('GPL2')
-depends=('dbus-glib>=0.94' 'libxml2>=2.4' 'systemd')
+makedepends=('systemd')
+depends=('dbus-glib>=0.94' 'libxml2>=2.4')
 conflicts=('thermald-git')
 backup=('etc/thermald/thermal-conf.xml')
 install="${pkgname}.install"

--- a/thermald/PKGBUILD
+++ b/thermald/PKGBUILD
@@ -5,7 +5,7 @@
 _pkgname=thermal_daemon
 pkgname=thermald
 pkgver=1.5
-pkgrel=1
+pkgrel=1.1
 pkgdesc="The Linux Thermal Daemon program from 01.org"
 arch=('i686' 'x86_64')
 url="https://github.com/01org/${_pkgname}"
@@ -14,7 +14,8 @@ makedepends=('systemd')
 depends=('dbus-glib>=0.94' 'libxml2>=2.4')
 conflicts=('thermald-git')
 backup=('etc/thermald/thermal-conf.xml')
-source=("https://github.com/01org/thermal_daemon/archive/v1.5.tar.gz")
+install="${pkgname}.install"
+source=("https://github.com/01org/thermal_daemon/archive/v${pkgver}.tar.gz")
 sha256sums=('48cec153097d19d4b1b5fba8bc7ee5801e8ff5d17c22714bbedd1f967ca1ece9')
           
 build() {

--- a/thermald/thermald.install
+++ b/thermald/thermald.install
@@ -1,0 +1,43 @@
+thermald_enabled() {
+    systemctl is-enabled thermald.service &> /dev/null
+    if [ $? -eq 0 ]; then
+        echo 'Service thermald is enabled already'
+    else
+        echo 'Enabling thermald service...'
+        systemctl enable thermald.service &> /dev/null
+    fi
+}
+
+thermald_active() {
+    systemctl is-active thermald.service &> /dev/null
+    if [ $? -eq 0 ]; then
+        echo 'Service thermald is active already'
+    else
+        echo 'Starting thermald service...'
+        systemctl start thermald.service &> /dev/null
+    fi
+}
+
+post_upgrade() {
+    thermald_enabled
+    thermald_active
+    systemctl daemon-reload
+}
+
+post_install() {
+    post_upgrade
+}
+
+pre_remove() {
+    echo 'Disabling thermald service...'
+    systemctl is-enabled thermald.service &> /dev/null
+    if [ $? -eq 0 ]; then
+        systemctl disable thermald.service &> /dev/null
+    fi
+    echo 'Stoping thermald service...'
+    systemctl is-active thermald.service &> /dev/null
+    if [ $? -eq 0 ]; then
+        systemctl stop thermald.service &> /dev/null
+    fi
+    systemctl daemon-reload
+}


### PR DESCRIPTION
Simple post install scripts for enabling and starting thermald systemd service OUT-OF-BOX after install, refresh state of services units after upgrade and clean up after removing. All tested PASSED localy.

@oberon2007 @philmmanjaro 