### PR TITLE
kde-servicemenus-rootactions 2.9

### DIFF
--- a/kde-servicemenus-rootactions/PKGBUILD
+++ b/kde-servicemenus-rootactions/PKGBUILD
@@ -2,23 +2,23 @@
 # Contributor: Jan Valiska <jan.valiska@gmail.com>
 
 pkgname=kde-servicemenus-rootactions
-pkgver=2.8.5
-pkgrel=3
+pkgver=2.9
+pkgrel=1
 pkgdesc="Allows admin users to perform several root only actions from dolphin via kdesu/kdesudo"
 arch=(any)
 url="http://www.kde-apps.org/content/show.php?content=48411"
 license=(GPL)
-depends=('kdebase-kdialog')
-optdepends=('kdebase-dolphin' 'kdeutils-ark')
-source=("http://www.kde-apps.org/CONTENT/content-files/48411-rootactions_servicemenu_$pkgver.tar.gz")
-md5sums=('ee2546b270187de2f06b9e62b2e20883')
+depends=('ark' 'dolphin' 'kdebase-kdialog')
+source=("http://kde-apps.org/CONTENT/content-files/48411-rootactions_servicemenu_${pkgver}.tar.gz")
+sha256sums=('0fd5653d11623648286e911631d6b82a45eb2db0f5a341b46289910b12c3abcc')
 
 package() {
-    cd $srcdir/rootactions_servicemenu_$pkgver/Root_Actions_$pkgver/dolphin-KDE4/
-    mkdir -p $pkgdir/usr/share/kde4/services/ServiceMenus/
-    mkdir -p $pkgdir/usr/share/kservices5/ServiceMenus/
-    install -m755 *.desktop $pkgdir/usr/share/kde4/services/ServiceMenus/
-    install -m755 *.desktop $pkgdir/usr/share/kservices5/ServiceMenus/
-    cd $srcdir/rootactions_servicemenu_$pkgver/Root_Actions_$pkgver 
-    install -Dm755 rootactions-servicemenu.pl $pkgdir/usr/bin/rootactions-servicemenu.pl
+    cd rootactions_servicemenu_$pkgver/Root_Actions_$pkgver/dolphin-KDE4/
+    mkdir -p "$pkgdir"/usr/share/kservices5/ServiceMenus
+    install -Dm755 *.desktop "$pkgdir"/usr/share/kservices5/ServiceMenus/
+    cd ../krusader-KDE4
+    install -Dm644 krusader_rootactions.xml "$pkgdir"/usr/share/apps/krusader/krusader_rootactions.xml
+    install -Dm644 krusader_rootactions.xml "$pkgdir"/usr/share/krusader/krusader_rootactions.xml
+    cd ..
+    install -Dm755 rootactions-servicemenu.pl "$pkgdir"/usr/bin/rootactions-servicemenu.pl
 } 


### PR DESCRIPTION
upstream update

> Changelog:
> 2.9 KF5 fixes
> - Support for kf5-kdesu not in $PATH
> - fixes in installer/uninstaller scripts
> - workaround: use --nofork to open konsole as root