### PR TITLE
Update bpswm packages, remove gtk2 dependency from lightfirefox

### DIFF
--- a/bspwm-manjaro/PKGBUILD
+++ b/bspwm-manjaro/PKGBUILD
@@ -4,7 +4,7 @@
 _pkgname=bspwm
 pkgname=${_pkgname}-manjaro
 pkgver=0.9.1
-pkgrel=13
+pkgrel=14
 pkgdesc='A tiling window manager based on binary space partitioning'
 arch=('i686' 'x86_64' 'armv7h')
 url="https://github.com/baskerville/${_pkgname}"

--- a/bspwm-manjaro/bspwmrc
+++ b/bspwm-manjaro/bspwmrc
@@ -23,7 +23,8 @@ bspc config history_aware_focus    true
 #bspc config initial_polarity second_child
 bspc config remove_disabled_monitors true
 bspc config remove_unplugged_monitors true
-
+## Honor size hints: do not make windows smaller than they wish to be
+#bspc config honor_size_hints true 
 
 ##Color settings
 bspc config normal_frame_opacity 1.0

--- a/bspwm-manjaro/sxhkdrc
+++ b/bspwm-manjaro/sxhkdrc
@@ -75,7 +75,7 @@ ctrl + space
 	
 # Presel window for splitting in certain direction
 alt + ctrl + {a,s,w,d}
-	bspc node -p \~{west,south,north,east}
+	bspc node -p \~{west,south,north,east} -i
 
 alt + ctrl + {h,j,k,l}
 	bspc node -p \~{west,south,north,east}
@@ -250,10 +250,10 @@ mod1 + @button1
 
 # These two are needed if you want to use xfdesktops menus while 
 # focus_follows_pointer is on
-@button3
-	clickpasser 3
-@button2
-	clickpasser 2
+#@button3
+#	clickpasser 3
+#@button2
+#	clickpasser 2
 
 #
 # Touchpad "gestures" (depend on your touchpad driver, very likely to be unavailable)
@@ -336,3 +336,7 @@ alt + ctrl + space
 super + ctrl + space
 	{pkill compton ,\
 	compton -b }
+
+# Remove receptacles
+super + BackSpace
+  for i in $(bspc query -N -n .leaf.!window.local); do bspc node $i -k; done

--- a/bspwm-scripts/PKGBUILD
+++ b/bspwm-scripts/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Chrysostomus @forum.manjaro.org
 
 pkgname=bspwm-scripts
-pkgver=0.26
+pkgver=0.27
 pkgrel=1
 pkgdesc="Scripts for controlling bspwm"
 arch=(any)

--- a/lemonpanel/PKGBUILD
+++ b/lemonpanel/PKGBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Chrysostomus
 
 pkgname=lemonpanel
-_ver=0.22
-pkgver=0.22.r178.72197ba
+_ver=0.23
+pkgver=0.23.r182.db80640
 pkgrel=1
 pkgdesc="Panel script for bspwm using patched dmenu and lemonbar"
 arch=('any')

--- a/lightfirefox/PKGBUILD
+++ b/lightfirefox/PKGBUILD
@@ -7,7 +7,7 @@ pkgrel=1
 pkgdesc="A light Firefox edition"
 url="http://sourceforge.net/projects/lightfirefox"
 license=('MPL')
-depends=('alsa-lib' 'dbus-glib' 'desktop-file-utils' 'gtk2' 'gtk3' 'libxt' 'mime-types' 'nss' 'shared-mime-info')
+depends=('alsa-lib' 'dbus-glib' 'desktop-file-utils' 'gtk3' 'libxt' 'mime-types' 'nss' 'shared-mime-info')
 provides=("${pkgname}=${_pkgver}")
 arch=('i686' 'x86_64')
 source_x86_64=("${pkgname/firefox}-${pkgver}.en-US.linux-x86_64.rpm::http://sourceforge.net/projects/${pkgname}/files/${_pkgver}/201606060706_gcc/${pkgname/firefox}-${pkgver}.en-US.linux-x86_64.rpm/download")

--- a/limepanel/PKGBUILD
+++ b/limepanel/PKGBUILD
@@ -2,8 +2,8 @@
 # Maintainer: Chrysostomus
 
 pkgname=limepanel
-_ver=0.26
-pkgver=0.26.r104.gf2a9497
+_ver=0.27
+pkgver=0.27.r104.gf2a9497
 pkgrel=1
 pkgdesc="Panel script for bspwm using patched dmenu and lemonbar"
 arch=('any')


### PR DESCRIPTION
Lightfirefox does not need gtk2 and adding it adds about 100mb to bspwm edition iso size.

@oberon2007 Can you rebuild these please?