### PR TITLE
[virtualbox] rm mod_timer_pinned

### DIFF
--- a/xorg/virtualbox/PKGBUILD
+++ b/xorg/virtualbox/PKGBUILD
@@ -88,7 +88,7 @@ md5sums=('aff1647170dd92914cddfbd0254b9773'
          'ecfd13297d7753ebe7b8763ca5b792d9'
          'd82a6f19be739341ed7f1cf4ee8070ca'
          '188ea65918309f737ce28216c2b07c3b'
-         '3b67c9549484d0a8aaa52734ec57363c')
+         '02aa3239b72c9414ae587cb0c7a9702f')
 
 prepare() {
     cd "VirtualBox-$pkgver"

--- a/xorg/virtualbox/PKGBUILD
+++ b/xorg/virtualbox/PKGBUILD
@@ -11,7 +11,7 @@ pkgname=('virtualbox'
          'virtualbox-guest-utils-nox'
          'virtualbox-ext-vnc')
 pkgver=5.1.2
-pkgrel=0.1
+pkgrel=0.2
 arch=('i686' 'x86_64')
 url='http://virtualbox.org'
 license=('GPL' 'custom')
@@ -69,6 +69,7 @@ source=("http://download.virtualbox.org/virtualbox/$pkgver/VirtualBox-$pkgver.ta
         '005-gsoap-build.patch'
         '006-rdesktop-vrdp-keymap-path.patch'
         '007-python2-path.patch'
+        'rm_mod_timer_pinned.patch'
         )
 md5sums=('aff1647170dd92914cddfbd0254b9773'
          'a19774e8c56f2c4d12c528992525c444'
@@ -86,7 +87,8 @@ md5sums=('aff1647170dd92914cddfbd0254b9773'
          '9e49bbaa2192b141c27ee43cef8cbab7'
          'ecfd13297d7753ebe7b8763ca5b792d9'
          'd82a6f19be739341ed7f1cf4ee8070ca'
-         '188ea65918309f737ce28216c2b07c3b')
+         '188ea65918309f737ce28216c2b07c3b'
+         '3b67c9549484d0a8aaa52734ec57363c')
 
 prepare() {
     cd "VirtualBox-$pkgver"

--- a/xorg/virtualbox/rm_mod_timer_pinned.patch
+++ b/xorg/virtualbox/rm_mod_timer_pinned.patch
@@ -1,5 +1,6 @@
---- a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c 2016-07-21 18:28:43.000000000 +0200
-+++ b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c 2016-07-26 21:32:57.560098525 +0200
+diff -ru a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c
+--- a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c	2016-07-21 18:28:43.000000000 +0200
++++ b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c	2016-07-27 17:27:12.024343500 +0200
 @@ -51,7 +51,7 @@
  #endif
  
@@ -9,7 +10,7 @@
  # define HRTIMER_MODE_ABS_PINNED        HRTIMER_MODE_ABS
  #endif
  
-@@ -359,12 +359,7 @@ static void rtTimerLnxStartSubTimer(PRTT
+@@ -359,12 +359,7 @@
          unsigned long cJiffies = !u64First ? 0 : rtTimerLnxNanoToJiffies(u64First);
          pSubTimer->u.Std.ulNextJiffies  = jiffies + cJiffies;
          pSubTimer->u.Std.fFirstAfterChg = true;
@@ -23,7 +24,7 @@
      }
  
      /* Be a bit careful here since we could be racing the callback. */
-@@ -794,12 +789,7 @@ static void rtTimerLinuxStdCallback(unsi
+@@ -794,12 +789,7 @@
          pTimer->pfnTimer(pTimer, pTimer->pvUser, iTick);
          if (RT_LIKELY(rtTimerLnxCmpXchgState(&pSubTimer->enmState, RTTIMERLNXSTATE_ACTIVE, RTTIMERLNXSTATE_CALLBACK)))
          {
@@ -37,7 +38,7 @@
              return;
          }
      }
-@@ -851,12 +841,7 @@ static void rtTimerLinuxStdCallback(unsi
+@@ -851,12 +841,7 @@
                                                      : jiffies;
                      spin_unlock_irqrestore(&pTimer->ChgIntLock, flFlags);
  
@@ -51,3 +52,12 @@
                      return;
                  }
                  break;
+@@ -1565,7 +1550,7 @@
+         else
+ #endif
+         {
+-            init_timer(&pTimer->aSubTimers[iCpu].u.Std.LnxTimer);
++            init_timer_pinned(&pTimer->aSubTimers[iCpu].u.Std.LnxTimer);
+             pTimer->aSubTimers[iCpu].u.Std.LnxTimer.data        = (unsigned long)&pTimer->aSubTimers[iCpu];
+             pTimer->aSubTimers[iCpu].u.Std.LnxTimer.function    = rtTimerLinuxStdCallback;
+             pTimer->aSubTimers[iCpu].u.Std.LnxTimer.expires     = jiffies;

--- a/xorg/virtualbox/rm_mod_timer_pinned.patch
+++ b/xorg/virtualbox/rm_mod_timer_pinned.patch
@@ -1,6 +1,5 @@
-diff -ru a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c
---- a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c	2016-07-21 18:28:43.000000000 +0200
-+++ b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c	2016-07-26 17:47:59.325792704 +0200
+--- a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c 2016-07-21 18:28:43.000000000 +0200
++++ b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c 2016-07-26 21:32:57.560098525 +0200
 @@ -51,7 +51,7 @@
  #endif
  
@@ -10,30 +9,45 @@ diff -ru a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c b/src/VBox/Runtime/r
  # define HRTIMER_MODE_ABS_PINNED        HRTIMER_MODE_ABS
  #endif
  
-@@ -361,7 +361,7 @@
+@@ -359,12 +359,7 @@ static void rtTimerLnxStartSubTimer(PRTT
+         unsigned long cJiffies = !u64First ? 0 : rtTimerLnxNanoToJiffies(u64First);
+         pSubTimer->u.Std.ulNextJiffies  = jiffies + cJiffies;
          pSubTimer->u.Std.fFirstAfterChg = true;
- #ifdef CONFIG_SMP
-         if (fPinned)
+-#ifdef CONFIG_SMP
+-        if (fPinned)
 -            mod_timer_pinned(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-+            mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-         else
- #endif
-             mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-@@ -796,7 +796,7 @@
-         {
- #ifdef CONFIG_SMP
-             if (pTimer->fSpecificCpu || pTimer->fAllCpus)
--                mod_timer_pinned(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-+                mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-             else
- #endif
-                 mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-@@ -853,7 +853,7 @@
+-        else
+-#endif
+-            mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
++        mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+     }
  
- #ifdef CONFIG_SMP
-                     if (pTimer->fSpecificCpu || pTimer->fAllCpus)
+     /* Be a bit careful here since we could be racing the callback. */
+@@ -794,12 +789,7 @@ static void rtTimerLinuxStdCallback(unsi
+         pTimer->pfnTimer(pTimer, pTimer->pvUser, iTick);
+         if (RT_LIKELY(rtTimerLnxCmpXchgState(&pSubTimer->enmState, RTTIMERLNXSTATE_ACTIVE, RTTIMERLNXSTATE_CALLBACK)))
+         {
+-#ifdef CONFIG_SMP
+-            if (pTimer->fSpecificCpu || pTimer->fAllCpus)
+-                mod_timer_pinned(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+-            else
+-#endif
+-                mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
++            mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+             return;
+         }
+     }
+@@ -851,12 +841,7 @@ static void rtTimerLinuxStdCallback(unsi
+                                                     : jiffies;
+                     spin_unlock_irqrestore(&pTimer->ChgIntLock, flFlags);
+ 
+-#ifdef CONFIG_SMP
+-                    if (pTimer->fSpecificCpu || pTimer->fAllCpus)
 -                        mod_timer_pinned(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-+                        mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
-                     else
- #endif
-                         mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+-                    else
+-#endif
+-                        mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
++                    mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+                     return;
+                 }
+                 break;

--- a/xorg/virtualbox/rm_mod_timer_pinned.patch
+++ b/xorg/virtualbox/rm_mod_timer_pinned.patch
@@ -1,0 +1,39 @@
+diff -ru a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c
+--- a/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c	2016-07-21 18:28:43.000000000 +0200
++++ b/src/VBox/Runtime/r0drv/linux/timer-r0drv-linux.c	2016-07-26 17:47:59.325792704 +0200
+@@ -51,7 +51,7 @@
+ #endif
+ 
+ #if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 31)
+-# define mod_timer_pinned               mod_timer
++# define mod_timer
+ # define HRTIMER_MODE_ABS_PINNED        HRTIMER_MODE_ABS
+ #endif
+ 
+@@ -361,7 +361,7 @@
+         pSubTimer->u.Std.fFirstAfterChg = true;
+ #ifdef CONFIG_SMP
+         if (fPinned)
+-            mod_timer_pinned(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
++            mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+         else
+ #endif
+             mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+@@ -796,7 +796,7 @@
+         {
+ #ifdef CONFIG_SMP
+             if (pTimer->fSpecificCpu || pTimer->fAllCpus)
+-                mod_timer_pinned(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
++                mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+             else
+ #endif
+                 mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+@@ -853,7 +853,7 @@
+ 
+ #ifdef CONFIG_SMP
+                     if (pTimer->fSpecificCpu || pTimer->fAllCpus)
+-                        mod_timer_pinned(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
++                        mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);
+                     else
+ #endif
+                         mod_timer(&pSubTimer->u.Std.LnxTimer, pSubTimer->u.Std.ulNextJiffies);


### PR DESCRIPTION
This solves a current [issue](https://github.com/manjaro/packages-community/issues/203) with the realtime patch rt8 where virtualbox-modules fail to compiled against linux-rt kernel due to ``mod_timer_pinned`` function still being needed by **vbox** while it has already been dropped in the rt-patched kernel.
Referring to rt-patch-author Sebastian Andrzej Siewior and Linuxkernel maintainer Thomas Gleixner the function will ultimately be dropped from linux48.
See: http://git.kernel.org/tip/177ec0a0a531695210b277d734b2f92ee5796303
and https://lkml.org/lkml/2016/7/25/142
Thomas Gleixner suggests a fix similar to this: http://marc.info/?l=linux-kernel&m=146762632027319&w=2
I've since opened a [ticket](https://www.virtualbox.org/ticket/15695) at **virtualbox** but it would be great meanwhile to patch our **vbox** (we are compiling it anyway).
@philmmanjaro what do you think? Could you please have a look at the code - I'm not so sure about C - syntax about how to cleanly drop those if statements.
In any case the attached commit has been tested by building and running the extramodules against some of our kernels and also rt8 without issues.