### PR TITLE
Update PKGBUILD for telegram-purple version 1.3.0

### DIFF
--- a/telegram-purple/PKGBUILD
+++ b/telegram-purple/PKGBUILD
@@ -1,8 +1,8 @@
 # Maintainer: Kendell Clark <coffeekingms@gmail.com>
 # Contributor:  Zhuoyun Wei <wzyboy@wzyboy.org>
 pkgname=telegram-purple
-pkgver=1.2.6
-pkgrel=3
+pkgver=1.3.0
+pkgrel=1
 pkgdesc="Adds support for Telegram to Pidgin, Adium, Finch and other Libpurple based messengers."
 arch=('i686' 'x86_64')
 url="https://github.com/majn/telegram-purple"
@@ -11,7 +11,7 @@ makedepends=("git")
 depends=('glib2' 'libgcrypt>=1.6.0' 'libpurple' 'zlib' 'libwebp')
 conflict=('telegram-purple-git')
 source=("https://github.com/majn/${pkgname}/releases/download/v${pkgver}/telegram-purple_${pkgver}.orig.tar.gz")
-sha256sums=('f643d56da0c2ab4ffe603542e3a485cd10d45936d8f6e7dfafec862aa81f2dbb')
+sha256sums=('83b299f3b6e896b68baa02c9bec0fb0d8ef1821d92fd8b1595499beb772c9203')
 
 build() {
   cd "${srcdir}/${pkgname}"


### PR DESCRIPTION
Copied the updates over from https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=telegram-purple