### PR TITLE
[octopi] Adapt sed command for the KSTATUS define for the kde notifier

### DIFF
--- a/octopi/PKGBUILD
+++ b/octopi/PKGBUILD
@@ -42,7 +42,7 @@ prepare() {
 
   cp -r notifier notifier-qt5
   cp -r notifier notifier-frameworks
-  sed -i 's|#DEFINES += KSTATUS|DEFINES += KSTATUS|' notifier-frameworks/octopi-notifier/octopi-notifier.pro
+  sed -i 's|DEFINES += ALPM_BACKEND #KSTATUS|DEFINES += ALPM_BACKEND KSTATUS|' notifier-frameworks/octopi-notifier/octopi-notifier.pro
 }
 
 build() {


### PR DESCRIPTION
Adapt sed command for KSTATUS in octopi-notifier-frameworks after the addition of ALPM_BACKEND in the .pro project file