### PR TITLE
dont echo 'modprobe uinput', do modprobe uinput

### DIFF
--- a/steam-manjaro/PKGBUILD
+++ b/steam-manjaro/PKGBUILD
@@ -8,7 +8,7 @@
 pkgname=steam-manjaro
 _package=steam
 pkgver=1.0.0.54
-pkgrel=3
+pkgrel=4
 pkgdesc="Valve's digital software delivery system"
 url='http://steampowered.com/'
 arch=('i686' 'x86_64')
@@ -31,7 +31,7 @@ source=(http://repo.steampowered.com/${_package}/pool/${_package}/s/${_package}/
         '0006-lib32_path_and_steam_runtime.patch'
         )
 md5sums=('d1398490635615c428165e984a1ec71b'
-         '76a80fcfbea2263b8848cc6acf8c58f7'
+         '30afc12115ce6a243c6ffab554e187eb'
          '895c8735878bc1611cf6e1ee71f60ee6'
          'a43df36943b5a6da88bc320c1abd0ca1'
          '12e3ca2521b33dac0c668e423a8a7c31'

--- a/steam-manjaro/steam-manjaro.install
+++ b/steam-manjaro/steam-manjaro.install
@@ -4,7 +4,7 @@ post_install()
     grep -q 'uinput' /proc/modules
     if [ ! $? -eq 0 ]
         then
-            echo "modprobe uinput"
+            modprobe uinput
     fi
 }
 


### PR DESCRIPTION
found something really bad from testing stage :/ 

Instead of loading the uinput driver at installation time, it will only echo "modprobe uinput". So the steam controller will only work after a restart. 

Lets fix this 👍 