### PR TITLE
workaround a steam/Plasma bug

### DIFF
--- a/steam-manjaro/PKGBUILD
+++ b/steam-manjaro/PKGBUILD
@@ -8,7 +8,7 @@
 pkgname=steam-manjaro
 _package=steam
 pkgver=1.0.0.54
-pkgrel=4
+pkgrel=5
 pkgdesc="Valve's digital software delivery system"
 url='http://steampowered.com/'
 arch=('i686' 'x86_64')
@@ -85,4 +85,8 @@ package()
     install -dm 755 "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
     ln -s "/usr/share/doc/steam/steam_install_agreement.txt" \
     "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+    # Workaround for KDE Plasma task managers
+    ## https://bugs.kde.org/show_bug.cgi?id=375598
+    mv "${pkgdir}/usr/share/applications/steam.desktop" "${pkgdir}/usr/share/applications/steam-valve.desktop"
 }

--- a/steam-manjaro/PKGBUILD
+++ b/steam-manjaro/PKGBUILD
@@ -8,7 +8,7 @@
 pkgname=steam-manjaro
 _package=steam
 pkgver=1.0.0.54
-pkgrel=5
+pkgrel=6
 pkgdesc="Valve's digital software delivery system"
 url='http://steampowered.com/'
 arch=('i686' 'x86_64')
@@ -31,7 +31,7 @@ source=(http://repo.steampowered.com/${_package}/pool/${_package}/s/${_package}/
         '0006-lib32_path_and_steam_runtime.patch'
         )
 md5sums=('d1398490635615c428165e984a1ec71b'
-         '30afc12115ce6a243c6ffab554e187eb'
+         '83d2eb7de772500a45f7e71b344519f2'
          '895c8735878bc1611cf6e1ee71f60ee6'
          'a43df36943b5a6da88bc320c1abd0ca1'
          '12e3ca2521b33dac0c668e423a8a7c31'

--- a/steam-manjaro/steam-manjaro.install
+++ b/steam-manjaro/steam-manjaro.install
@@ -2,7 +2,7 @@ post_install()
 {
     ## Load uinput if it is not loaded already
     grep -q 'uinput' /proc/modules
-    if [ ! $? -eq 0 ]
+    if [ ! $? -eq 0 ] && [ -d "/lib/modules/$(uname -r)" ]
         then
             modprobe uinput
     fi


### PR DESCRIPTION
This little change let's steam integrate better in plasma desktop (and wont effect other setups)
https://bugs.kde.org/show_bug.cgi?id=375598

I dont know it it is a bug in steam or in Plasma but since its an annoying bug that exists for a long time (ever?) and the KDE edition is one of the "main" edition of Manjaro, let's workaround it until there is a proper fix.

right now when you create a launcher in Plasmas Taskmanager and close steam, you can not start steam again
![screenshot_20170126_225654](https://cloud.githubusercontent.com/assets/18744080/22352357/0df83464-e41c-11e6-9ea0-f5584b818061.png)

also the rightclick actions do not work
![screenshot_20170126_225624](https://cloud.githubusercontent.com/assets/18744080/22352366/1c2994ce-e41c-11e6-8d32-a71bea1116d5.png)

this workaround just renames the steam.desktop file to steam-valve.desktop and everything works
![screenshot_20170126_225759](https://cloud.githubusercontent.com/assets/18744080/22352415/579052d2-e41c-11e6-838d-a577358c133c.png)

