### PR TITLE
bumblebee: adding workaround for libglvnd

### DIFF
--- a/bumblebee/PKGBUILD
+++ b/bumblebee/PKGBUILD
@@ -6,10 +6,10 @@
 ### NOTE ### Forked sources have merged ALL major fixes from develop branch (https://github.com/Bumblebee-Project/Bumblebee/commits/develop)
 ### Reference: https://forum.manjaro.org/t/bumblebee-not-switching-back-to-igpu-after-quitting-optirun/1054/12?u=fademind
 
-_commit=029ddaca064756c0a54bc67a9d5e1ed9d0aeb676 # lastest commit from 20170217
+_commit=0851da6818e265d354d61947021c512f2e51ffce # lastest commit from 20170227
 pkgname=bumblebee
 pkgver=3.2.1
-pkgrel=16
+pkgrel=17
 pkgdesc="NVIDIA Optimus support for Linux through Primus/VirtualGL"
 arch=('i686' 'x86_64')
 depends=('kmod' 'primus' 'glib2' 'mesa-libgl')
@@ -29,7 +29,7 @@ backup=('etc/bumblebee/bumblebee.conf'
         'etc/bumblebee/xorg.conf.nvidia')
 install='bumblebee.install'
 source=("${pkgname}.zip::https://github.com/FadeMind/Bumblebee/archive/${_commit}.zip")
-sha256sums=('709aabd1aff041e0b89cacc5a47083326f6c5ce22644e75d9a7ebfdd35c80fe2')
+sha256sums=('e50a3948c3320f65cd449a6dbe1c744cfc671a42ccb529a7dc797d1191a3df1c')
 
 build() {    
     cd "${srcdir}/Bumblebee-${_commit}"


### PR DESCRIPTION
Original: https://github.com/Bumblebee-Project/Bumblebee/pull/845

Merged in 
https://github.com/FadeMind/Bumblebee/commit/0851da6818e265d354d61947021c512f2e51ffce

Reference: https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/bumblebee&id=a9569bdd93b30be222f701245b5ff1dac10fbf34

@oberon2007  @philmmanjaro @Kirek 