### PR TITLE
lxde settings: replace breath-wallpaper dependency with lxde-wallpapers

### DIFF
--- a/desktop-settings/PKGBUILD
+++ b/desktop-settings/PKGBUILD
@@ -95,7 +95,7 @@ package_manjaro-lxde-settings() {
     depends=('manjaro-base-skel'
     	     'arc-maia-icon-theme'
 	     'vertex-maia-themes'
-	     'breath-wallpaper'
+	     'lxde-wallpapers'
 	     'qt5ct'
 	     'qt5-styleplugins'
 	     'manjaro-lxde-logout-banner')


### PR DESCRIPTION
I will also change the default wallpaper on **desktop-settings/community/lxde**. The only drawback I can think of, is that the package **breath-wallpaper** will possible become orphaned and it might gets some users which have it pre-installed confused. However, this shouldn't be a problem because if a user is experienced enough in order to remove orphan packages, then he would also think to change his wallpaper to something else if he removes **breath-wallpaper**