### PR TITLE
better use released tarball instead of github's source

### DIFF
--- a/mate/mate-indicator-applet/PKGBUILD
+++ b/mate/mate-indicator-applet/PKGBUILD
@@ -2,20 +2,19 @@
 
 pkgname=mate-indicator-applet
 pkgver=1.18.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Applet to display information from various applications consistently in the MATE panel."
 arch=('i686' 'x86_64')
 url="https://github.com/mate-desktop/$pkgname"
 license=('GPLv3')
-makedepends=("intltool" "autoconf" "mate-common")
+makedepends=("intltool")
 depends=("mate-panel" "libappindicator-gtk3" 'ido')
 optdepends=('indicator-sound')
-source=("$url/archive/v${pkgver}.tar.gz")
-md5sums=('1f78fe11afaf074be8378e222289046d')
+source=("https://pub.mate-desktop.org/releases/1.18/$pkgname-$pkgver.tar.xz")
+sha256sums=('4fe04328f2d86a1f0817e320a0fb841f7eb5839d0ae5131b44a8413d49489829')
 
 build() {
     cd $pkgname-$pkgver
-    $srcdir/$pkgname-$pkgver/autogen.sh
     ./configure --prefix=/usr
     make
 }


### PR DESCRIPTION
@Ste74 If you use the released tarball from https://pub.mate-desktop.org/releases/1.18/ then you can avoid the **mate-common** build dependency. I don't know if it's important. Tell me what you think.