### PR TITLE
manjaro-lxde-settings: add xfce4-notifyd dependency

### DIFF
--- a/desktop-settings/PKGBUILD
+++ b/desktop-settings/PKGBUILD
@@ -98,7 +98,8 @@ package_manjaro-lxde-settings() {
 	     'lxde-wallpapers'
 	     'qt5ct'
 	     'qt5-styleplugins'
-	     'manjaro-lxde-logout-banner')
+	     'manjaro-lxde-logout-banner'
+	     'xfce4-notifyd')
     conflicts=('manjaro-desktop-settings')
     provides=('manjaro-desktop-settings')
 


### PR DESCRIPTION
I haven't included any notification daemon. This is needed for many messages (like pamac updates) and for the new scrot script. I add it as a dependency for **manjaro-lxde-settings** and I don't just include it in the Packages-Desktop file, so that users who have already installed this edition will get it installed too after the new package gets in the stable branch.