### PR TITLE
adds a script to workaround steam-bug #4816

### DIFF
--- a/steam-manjaro/PKGBUILD
+++ b/steam-manjaro/PKGBUILD
@@ -8,7 +8,7 @@
 pkgname=steam-manjaro
 _package=steam
 pkgver=1.0.0.54
-pkgrel=7
+pkgrel=8
 pkgdesc="Valve's digital software delivery system"
 url='http://steampowered.com/'
 arch=('i686' 'x86_64')
@@ -30,6 +30,8 @@ source=(http://repo.steampowered.com/${_package}/pool/${_package}/s/${_package}/
 # 20170503 (date +%Y%m%d) disable ld_library_path_fallback for now.
 #        '0006-ld_library_path_fallback_x86.patch'
 #        '0006-ld_library_path_fallback_x86_64.patch'
+# bug #4816 https://github.com/ValveSoftware/steam-for-linux/issues/4816
+        'steam_install_workaround'
         )
 sha512sums=('1820f596359d829a4e119f1f916a741ecb7973d36684916cdbbfa435fcdc9c288852491fd6d0b064e8154a43c60d8dcce3c7ed9275aed8f5f116c2782489bf32'
             '8f3a781077bba4a1d5d06943060e01a21800d5cfba91262502c47810499c5b9367c10d1c319bb9ba006b143ddc5159f2826c8f3229322bc9fe28c1fcf66ea103'
@@ -38,7 +40,8 @@ sha512sums=('1820f596359d829a4e119f1f916a741ecb7973d36684916cdbbfa435fcdc9c28885
             '4f9e92268f6624e36ae9a987118af0e38bf51b73a4493863a80a558e0807171fc0343131dc197f8fc5bc48452978428092d69a306a2cf2710520baba564a5aaa'
             'ec57f189fbc25633799c553b0eb30bd074f02befd9c7e7ca1c052be0a66ca3745b511b0fccb21ddb57885d60a23c8d40eaa8d63f8da2fc2fff3b8e7f5d23b091'
             '12d8b5786e2a375ec03131ff5c246c64793acc24cf42e74b40cd77a031c17543da05f7dd33b1f17f63524710f5d96636f35908e1953292f44e949f84fb753c27'
-            'fec7a63231c502debaa8ccdac73270e47ad42dd85e420eee44100ed0e4e4678e9ad70e36a3df02cc9ebe9936b710737d0867532a9b319bc1bee141c420db5900')
+            'fec7a63231c502debaa8ccdac73270e47ad42dd85e420eee44100ed0e4e4678e9ad70e36a3df02cc9ebe9936b710737d0867532a9b319bc1bee141c420db5900'
+            'a5eb16810f2e1f1b6fbb627dba7ae74da2f375885f79ab829f918f541861ccde360c6d658b30236e7b8fad789ab98a1c35be1a08f6b19853ec338863b8caccc8')
 
 prepare()
 {
@@ -84,4 +87,8 @@ package()
     install -dm 755 "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
     ln -s "/usr/share/doc/steam/steam_install_agreement.txt" \
     "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+
+    # bug #4816 https://github.com/ValveSoftware/steam-for-linux/issues/4816
+    install -D -m755 "${srcdir}/steam_install_workaround" \
+    "${pkgdir}/usr/bin/steam_install_workaround"
 }

--- a/steam-manjaro/steam_install_workaround
+++ b/steam-manjaro/steam_install_workaround
@@ -1,0 +1,19 @@
+#!/bin/sh
+## This script works around bug #4816 https://github.com/ValveSoftware/steam-for-linux/issues/4816
+## that is still present at installation time.
+
+if [ "$(whoami)" = "root" ]
+    then
+        echo "root is not supported"
+        exit 1
+fi
+
+export LANG="C"
+export LD_PRELOAD='/usr/$LIB/libstdc++.so.6 /usr/$LIB/libgcc_s.so.1 /usr/$LIB/libxcb.so.1 /usr/$LIB/libgpg-error.so'
+export LIBGL_DRI3_DISABLE="1"
+
+xdg-open https://github.com/ValveSoftware/steam-for-linux/issues/4816 &
+
+/usr/bin/steam "${@}"
+
+exit 0


### PR DESCRIPTION
while bug https://github.com/ValveSoftware/steam-for-linux/issues/4816 is fixed on client side, its still present at installation time. So users get 

```
libGL error: unable to load driver: drivername_dri.so
libGL error: driver pointer missing
```

or 

```
/home/$USER/.local/share/Steam/ubuntu12_32/steam: symbol lookup error: /usr/lib32/libxcb-dri3.so.0: undefined symbol: xcb_send_request_with_fds
```

while trying to start steam for the first time.

It is not integrated in the steam launch script, because there seems to be no easy way to check if this is the first time you start steam, or the first time after a `steam --reset`.
We also don't want to add this by default for every steam instance, because this breaks some games.

I have also added the line

```
xdg-open https://github.com/ValveSoftware/steam-for-linux/issues/4816 &
```
that will open the browser with the bugreport, to generate more pressure on this bug. .

