### PR TITLE
add pulseaudio-ctl dependency to manjaro-lxde-settings

### DIFF
--- a/desktop-settings/PKGBUILD
+++ b/desktop-settings/PKGBUILD
@@ -120,6 +120,7 @@ package_manjaro-lxde-settings() {
 	     'manjaro-lxde-logout-banner'
 	     'manjaro-lxde-xfce4-notifyd'
 	     'i3-scrot'
+	     'pulseaudio-ctl'
 	     'xcursor-breeze')
     conflicts=('manjaro-desktop-settings')
     provides=('manjaro-desktop-settings')


### PR DESCRIPTION
**pulseaudio-ctl** is already included in the Packages Desktop, but just to make sure that it gets installed if someone want to install **manjaro-lxde-settings** on another installation since it's needed because of this change:
https://github.com/manjaro/desktop-settings/pull/91