### PR TITLE
Add: manjaro-lxde-xfce4-volumed-pulse

### DIFF
--- a/desktop-settings/PKGBUILD
+++ b/desktop-settings/PKGBUILD
@@ -120,7 +120,7 @@ package_manjaro-lxde-settings() {
 	     'manjaro-lxde-logout-banner'
 	     'manjaro-lxde-xfce4-notifyd'
 	     'i3-scrot'
-	     'pulseaudio-ctl'
+	     'manjaro-lxde-xfce4-volumed-pulse'
 	     'xcursor-breeze')
     conflicts=('manjaro-desktop-settings')
     provides=('manjaro-desktop-settings')

--- a/lxde/manjaro-lxde-xfce4-volumed-pulse/PKGBUILD
+++ b/lxde/manjaro-lxde-xfce4-volumed-pulse/PKGBUILD
@@ -1,0 +1,17 @@
+# Mainatiner: ThanosApostolou <forum@manjaro.org>
+
+pkgname=manjaro-lxde-xfce4-volumed-pulse
+pkgver=0.1
+pkgrel=1
+pkgdesc="desktop entry to autostart xfce4-volumed-pulse under Lxde"
+url=" "
+arch=('any')
+license=('GPL2')
+depends=('xfce4-volumed-pulse')
+source=('manjaro-lxde-xfce4-volumed-pulse.desktop')
+sha256sums=('54df2ff49eacc59578428779e438bf07dc2b61d87d09666276b90780fde14d56')
+
+package() {
+	cd $srcdir
+	install -Dm644 manjaro-lxde-xfce4-volumed-pulse.desktop $pkgdir/etc/xdg/autostart/manjaro-lxde-xfce4-volumed-pulse.desktop
+}

--- a/lxde/manjaro-lxde-xfce4-volumed-pulse/manjaro-lxde-xfce4-volumed-pulse.desktop
+++ b/lxde/manjaro-lxde-xfce4-volumed-pulse/manjaro-lxde-xfce4-volumed-pulse.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Type=Application
+Terminal=false
+Name=XFCE Volume Daemon working with LXDE (Pulseaudio)
+Comment=Daemon managing the volume multimedia keys and displaying volume notifications for Pulseaudio
+Exec=xfce4-volumed-pulse
+OnlyShowIn=LXDE;
+Name[en_US]=manjaro-lxde-xfce4-volumed-pulse


### PR DESCRIPTION
I want to use **xfce4-volumed-pulse** for handling the volume keys and the notifications, which is far better than the lxde applet, or the openbox shortcuts+ pulseaudio-ctl commands. However, the **/etc/xdg/autostart/xfce4-volumed-pulse.desktop** has a line **OnlyShowIn=XFCE;**. I thought to put a custom desktop entry in **~/.config/autostart/** but if someone remove **lxde** and **manjaro-lxde-settings**, this desktop entry will be left in the home folder untouched. So, I believe it's "cleaner" to create a package like I did with **manjaro-lxde-xfce4-notifyd**.