### PR TITLE
Add pacaur to hook targets

### DIFF
--- a/manjaro-aur-support/manjaro-aur-support.hook
+++ b/manjaro-aur-support/manjaro-aur-support.hook
@@ -2,6 +2,7 @@
 Operation = Install
 Operation = Upgrade
 Type = Package
+Target = pacaur
 Target = yaourt
 
 [Action]


### PR DESCRIPTION
Other helpers should be added to the hook targets; this patch adds pacaur.