### PR TITLE
mate-tweak: add support for mutiny-no-indicators and eleven-no-indicators (cupertino)

### DIFF
--- a/mate/mate-tweak/PKGBUILD
+++ b/mate/mate-tweak/PKGBUILD
@@ -5,7 +5,7 @@
 
 pkgname=mate-tweak
 pkgver=17.10.9
-pkgrel=2
+pkgrel=3
 pkgdesc="Tweak tool for MATE, a fork of MintDesktop."
 arch=('any')
 url="https://github.com/ubuntu-mate/mate-tweak"
@@ -13,15 +13,16 @@ license=('GPL')
 depends=('gtk3' 'libnotify' 'mate-applets' 'python-configobj' 'python-gobject' 'python-psutil' 'python-setproctitle')
 makedepends=('python-distutils-extra' 'python-setuptools')
 optdepends=('brisk-menu: for Manjaro panel layout'
-            'mate-applet-dock: for Mutiny panel layout'
+			'mate-applet-dock: for Mutiny panel layout'
             'mate-menu: to enable advanced menu'
             'mate-netbook: for Netbook panel layout'
             'plank: for Cupertino panel layout'
+            'vala-panel-appmenu-mate-git: for Mutiny,Cupertino'
             'tilda: to enable pull-down terminal')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/ubuntu-mate/$pkgname/archive/$pkgver.tar.gz"
-        "mate-tweak.patch")
+		"mate-tweak.patch")
 sha256sums=('e4fcf699cccdb01f7bd8b00b5f4ba25ab943c59b254c3ac36d2622ea1820b352'
-            'bd2b39db22d7ca4f00bed78857820831b9b8f96f605f182eed4ebf40b582cc34')
+			'6743f9731d66ffdad3a7b84d87a8710e9188accbe5bf5cf99578458f3857e280')
 
 prepare() {
 	cd $pkgname-$pkgver

--- a/mate/mate-tweak/PKGBUILD
+++ b/mate/mate-tweak/PKGBUILD
@@ -13,16 +13,16 @@ license=('GPL')
 depends=('gtk3' 'libnotify' 'mate-applets' 'python-configobj' 'python-gobject' 'python-psutil' 'python-setproctitle')
 makedepends=('python-distutils-extra' 'python-setuptools')
 optdepends=('brisk-menu: for Manjaro panel layout'
-			'mate-applet-dock: for Mutiny panel layout'
+            'mate-applet-dock: for Mutiny panel layout'
             'mate-menu: to enable advanced menu'
             'mate-netbook: for Netbook panel layout'
             'plank: for Cupertino panel layout'
             'vala-panel-appmenu-mate-git: for Mutiny,Cupertino'
             'tilda: to enable pull-down terminal')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/ubuntu-mate/$pkgname/archive/$pkgver.tar.gz"
-		"mate-tweak.patch")
+        "mate-tweak.patch")
 sha256sums=('e4fcf699cccdb01f7bd8b00b5f4ba25ab943c59b254c3ac36d2622ea1820b352'
-			'6743f9731d66ffdad3a7b84d87a8710e9188accbe5bf5cf99578458f3857e280')
+            '6743f9731d66ffdad3a7b84d87a8710e9188accbe5bf5cf99578458f3857e280')
 
 prepare() {
 	cd $pkgname-$pkgver

--- a/mate/mate-tweak/PKGBUILD
+++ b/mate/mate-tweak/PKGBUILD
@@ -17,7 +17,7 @@ optdepends=('brisk-menu: for Manjaro panel layout'
             'mate-menu: to enable advanced menu'
             'mate-netbook: for Netbook panel layout'
             'plank: for Cupertino panel layout'
-            'vala-panel-appmenu-mate-git: for Mutiny,Cupertino'
+            'vala-panel-appmenu-mate: for Mutiny,Cupertino'
             'tilda: to enable pull-down terminal')
 source=("$pkgname-$pkgver.tar.gz::https://github.com/ubuntu-mate/$pkgname/archive/$pkgver.tar.gz"
         "mate-tweak.patch")

--- a/mate/mate-tweak/mate-tweak.patch
+++ b/mate/mate-tweak/mate-tweak.patch
@@ -1,5 +1,5 @@
 --- mate-tweak	2017-07-20 00:25:42.000000000 +0300
-+++ mate-tweak.new	2017-07-31 20:49:36.753695000 +0300
++++ mate-tweak.new	2017-08-01 16:46:58.363141000 +0300
 @@ -480,15 +480,6 @@
              if metacity_schema:
                  self.set_string('org.gnome.metacity.theme', None, 'name', mate_theme)
@@ -42,7 +42,7 @@
  
          if os.path.exists('/usr/lib/mate-panel/appmenu-mate') and \
              os.path.exists('/usr/share/mate-panel/applets/org.vala-panel.appmenu.mate-panel-applet'):
-@@ -1181,6 +1168,19 @@
+@@ -1181,6 +1168,32 @@
          if self.panel_layout_exists('ubuntu-mate'):
              panels.append([_("Traditional"), "ubuntu-mate"])
  
@@ -58,6 +58,19 @@
 +           self.maximus_available and \
 +           not self.indicators_available:
 +            panels.append([_("Netbook (no indicators)"), "netbook-no-indicators"])
++
++        if self.panel_layout_exists('mutiny-no-indicators') and \
++           self.mate_dock_available and \
++           self.appmenu_applet_available and \
++           not self.indicators_available:
++            panels.append([_("Mutiny (no indicators)"), "mutiny-no-indicators"])
++
++        if self.dock is not None and \
++           self.appmenu_applet_available and \
++           self.brisk_menu_available and \
++           not self.indicators_available:
++            if self.panel_layout_exists('eleven-no-indicators'):
++                panels.append([_("Cupertino (no indicators)"), "eleven-no-indicators"])
 +
          self.builder.get_object("combobox_panels").set_model(panels)
  


### PR DESCRIPTION
@Ste74 These 2 panel layouts are depending on `vala-panel-appmenu-mate-git` in order to be visible on mate tweak. Are you willing to build it and include it in the manjaro repositories? If you do then change also the Optdepend on the mate-tweak PKGBUILD, because I'm guessing that you will remove the ending **-git** from the name.