### PR TITLE
Replace deepin-tool-kit with dtkwidget

### DIFF
--- a/deepin-manjaro/deepin-session-ui/PKGBUILD
+++ b/deepin-manjaro/deepin-session-ui/PKGBUILD
@@ -16,7 +16,7 @@ groups=('deepin')
 depends=('deepin-control-center'
     'deepin-daemon'
     'deepin-qt-dbus-factory'
-    'deepin-tool-kit'
+    'dtkwidget'
     'gsettings-qt'
     'gtk2'
     'liblightdm-qt5'


### PR DESCRIPTION
Looking at arch's `deepin-session-ui` PKGBUILD : 

https://git.archlinux.org/svntogit/community.git/commit/trunk?h=packages/deepin-session-ui&id=65c1eba3e16866751a04994b4dfac7c40fb7078b

It seems they have changed `deepin-tool-kit` into `dtkwidget` as depends and removed the `deepin-tool-kit` into oblivion (Arch repo) (I see it got removed as well in manjaro repo )....

So I think we should follow their step as well