### PR TITLE
lxde: change theme from vertex to adapta, remove xfce4-notifyd dependency

### DIFF
--- a/desktop-settings/PKGBUILD
+++ b/desktop-settings/PKGBUILD
@@ -117,12 +117,11 @@ package_manjaro-lxde-settings() {
     pkgdesc='Manjaro Linux lxde settings'
     depends=('manjaro-base-skel'
     	 'arc-maia-icon-theme'
-	     'vertex-maia-themes'
+	     'adapta-maia-theme'
 	     'lxde-wallpapers'
 	     'qt5ct'
 	     'qt5-styleplugins'
 	     'manjaro-lxde-logout-banner'
-	     'manjaro-lxde-xfce4-notifyd'
 	     'i3-scrot'
 	     'manjaro-lxde-xfce4-volumed-pulse'
 	     'xcursor-breeze')


### PR DESCRIPTION
manjaro-lxde-xfce4-notifyd is included in Packages-Desktop, there's no need to be a dependency for manjaro-lxde-settings (no configuration is depending on that and users should be able to use alternative notification daemons).