### PR TITLE
Make blurlock to turn off the screen after 15s

### DIFF
--- a/i3/i3exit/blurlock
+++ b/i3/i3exit/blurlock
@@ -1,6 +1,10 @@
 #!/bin/bash
 # /usr/bin/blurlock
 
+revert_dpms() {
+  xset dpms 0 0 0
+}
+
 # take screenshot
 import -window root /tmp/screenshot.png
 
@@ -8,7 +12,14 @@ import -window root /tmp/screenshot.png
 convert /tmp/screenshot.png -blur 0x5 /tmp/screenshotblur.png
 rm /tmp/screenshot.png
 
+# set the screen to turn off after 15s
+trap revert_dpms HUP INT TERM
+xset +dpms dpms 15 15 15
+
 # lock the screen
-i3lock -i /tmp/screenshotblur.png
+i3lock -n -i /tmp/screenshotblur.png
+
+# revert changes after screen is unlocked
+revert_dpms
 
 exit 0


### PR DESCRIPTION
As of version 2.8 i3lock does not support DPMS settings. Instead, they added a handy script to the man page.
This is basically an integration of the script from the man page and blurlock. For me, this is constantly saving a lot of battery on the laptop.

Tested only with one display. It's said that script from man page should be working correctly for multiple displays.
See https://www.mankier.com/1/i3lock#Dpms