### PR TITLE
bumblebee: waking from suspend fix

### DIFF
--- a/bumblebee/PKGBUILD
+++ b/bumblebee/PKGBUILD
@@ -9,7 +9,7 @@
 _commit=0851da6818e265d354d61947021c512f2e51ffce # lastest commit from 20170227
 pkgname=bumblebee
 pkgver=3.2.1
-pkgrel=18
+pkgrel=19
 pkgdesc="NVIDIA Optimus support for Linux through Primus/VirtualGL"
 arch=('i686' 'x86_64')
 depends=('kmod' 'primus' 'glib2' 'mesa-libgl')
@@ -63,4 +63,10 @@ package() {
     # Stop nvidia from loading on boot
     mkdir -p "${pkgdir}/etc/modprobe.d"
     echo "remove nvidia modprobe -r --ignore-remove nvidia-drm nvidia-modeset nvidia-uvm nvidia" > "${pkgdir}/etc/modprobe.d/bumblebee.conf"
+
+    # Enable NVIDIA card after waking from suspend
+    # The bumblebee daemon may fail to activate the graphics card after suspending. 
+    # A possible fix involves setting bbswitch as the default method for power management
+    # https://forum.manjaro.org/t/35257/21
+    sed -i "s/PMMethod=auto/PMMethod=bbswitch/" "${pkgdir}/etc/bumblebee/bumblebee.conf"
 }


### PR DESCRIPTION
Enable NVIDIA card after waking from suspend
The bumblebee daemon may fail to activate the graphics card after suspending. 
A possible fix involves setting bbswitch as the default method for power management

https://forum.manjaro.org/t/35257/21

CC @philmmanjaro 