### PR TITLE
spotify small install files fixes

### DIFF
--- a/spotify/PKGBUILD
+++ b/spotify/PKGBUILD
@@ -3,7 +3,7 @@
 # Contributor: Eothred <yngve.levinsen@gmail.com>
 
 # Check for new Linux releases:
-# $ wget "http://repository.spotify.com/pool/non-free/s/spotify-client/" -q -O /tmp/sv.html && awk '{print $2;}' /tmp/sv.html |cut -b 7-44|grep spotify;rm /tmp/sv.html
+# $ wget "http://repository.spotify.com/pool/non-free/s/spotify-client/" -q -O /tmp/sv.html && awk '{print $2;}' /tmp/sv.html |cut -b 7-50|grep spotify;rm /tmp/sv.html
 
 pkgname=spotify
 pkgver=1.0.77.338

--- a/spotify/PKGBUILD
+++ b/spotify/PKGBUILD
@@ -2,6 +2,9 @@
 # Contributor: Ashley Whetter <(firstname) @ awhetter.co.uk>
 # Contributor: Eothred <yngve.levinsen@gmail.com>
 
+# Check for new Linux releases:
+# $ wget "http://repository.spotify.com/pool/non-free/s/spotify-client/" -q -O /tmp/sv.html && awk '{print $2;}' /tmp/sv.html |cut -b 7-44|grep spotify;rm /tmp/sv.html
+
 pkgname=spotify
 pkgver=1.0.77.338
 _anotherpkgver=.g758ebd78

--- a/spotify/PKGBUILD
+++ b/spotify/PKGBUILD
@@ -22,7 +22,7 @@ source=("http://repository.spotify.com/pool/non-free/s/spotify-client/spotify-cl
         'spotify.protocol'
         'LICENSE')
 sha256sums=('0698d2dbda43f2866d2a6f6ed9816bf8022aa8cf67d0dba347f486410093e1a4'
-            '694d5f124e55f6dfe62d053ff41d5ff9ecca915c6335874db5efb8d2ac5468b0'
+            '2bd1072e1c9d0466e0f64a99e5d5b3c558c596b59a9730e627e65e57e02caa87'
             'af54f3b90cac46fa100b3f919a9225d10d847617d24aa9af3d832e7689f482c3'
             '4e8bea31ca27e16cac9c9dcd8f6ec27e1f82b45de86d6fee7a1e77e23f884b92')
 

--- a/spotify/clean-sc
+++ b/spotify/clean-sc
@@ -20,6 +20,6 @@ if [ -d "$HOME/.cache/spotify" ] && [ -d "$HOME/.cache/spotify/Browser/Cache" ] 
     printf "${BD}INFO :: AFTER CLEANING${NM}\n"
     du -h -d 0 $HOME/.cache/spotify
 else
-    printf "${BD}ERROR :: Spotify cache directories was not found. Exit.${NM}\n"
+    printf "${BD}ERROR :: Spotify cache directories were not found. Exit.${NM}\n"
     exit 1
 fi

--- a/spotify/spotify.install
+++ b/spotify/spotify.install
@@ -17,5 +17,5 @@ post_install() {
 }
 
 post_upgrade() {
-    post_install
+    note "Use clean-sc tool for cleanup spotify cache if needed."
 }


### PR DESCRIPTION
- `clean-sc` typo.
- `spotify.install` be sure that notice will be show up.
- `PKGBUILD` checksums update against `clean-sc` update.

Rebuild **IS NOT REQUIRED**. These changes are for future spotify releases.

@Ste74  @philmmanjaro 