### PR TITLE
Update webdad alpha7

### DIFF
--- a/manjaro-webdad-settings-git/PKGBUILD
+++ b/manjaro-webdad-settings-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgname=manjaro-webdad-settings
 pkgname="$_pkgname-git"
-pkgver=r16.3ed75e6
+pkgver=r17.6c9e694
 pkgrel=1
 pkgdesc="Manjaro WebDad Settings"
 arch=('any')
@@ -13,7 +13,7 @@ source=("git+$url.git")
 sha256sums=('SKIP')
 conflicts=('manjaro-webdad-settings')
 provides=('manjaro-webdad-settings')
-depends=('webdad-theming' 'webdad-workspaces' 'feh' 'dex' 'qt5-styleplugins')
+depends=('webdad-theming' 'dex' 'qt5-styleplugins')
 
 pkgver() {
     cd "$_pkgname"
@@ -26,5 +26,6 @@ package(){
 	install -d $pkgdir/etc
         install -d $pkgdir/usr
 	cp -r $srcdir/$_pkgname/etc $pkgdir/
+        install -Dm755 "$srcdir/$_pkgname/usr/bin/start-jade" "$pkgdir/usr/bin/start-jade"
         cp -r $srcdir/$_pkgname/usr $pkgdir/
 }

--- a/webdad-theming-git/PKGBUILD
+++ b/webdad-theming-git/PKGBUILD
@@ -13,7 +13,7 @@ source=("git+$url.git")
 sha256sums=('SKIP')
 conflicts=('webdad-theming')
 provides=('webdad-theming')
-depends=('adapta-maia-theme')
+depends=('adapta-maia-theme' 'paper-icon-theme-git' 'xcursor-breeze' 'adapta-kde' 'kvantum-theme-adapta')
 
 pkgver() {
     cd "$_pkgname"


### PR DESCRIPTION
webdad-workspaces can be removed, this is so i can test on unstable and see if the ISO builds properly, probably will send another pull request after i test this. 

webdad-theming
manjaro-webdad-settings

needs a rebuild