### PR TITLE
gimp-devel add dep, rebuild against gcc

### DIFF
--- a/gimp-devel/PKGBUILD
+++ b/gimp-devel/PKGBUILD
@@ -3,14 +3,14 @@
 _pkgname=gimp
 pkgname=${_pkgname}-devel
 pkgver=2.10.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GNU Image Manipulation Program (Development version)"
 arch=('i686' 'x86_64')
 url="http://www.gimp.org/"
 license=('GPL' 'LGPL')
 depends=('pygtk' 'lcms' 'libxpm' 'libwmf' 'libxmu' 'librsvg' 'libmng' 'dbus-glib'
          'libexif' 'gegl>=0.4.0' 'jasper' 'desktop-file-utils' 'hicolor-icon-theme' 'babl>=0.1.46'
-         'openexr' 'libgudev' 'libgexiv2' 'libmypaint>=1.3.0' 'libwebp' 'aalib' 'mypaint-brushes')
+         'openexr' 'libgudev' 'libgexiv2' 'libmypaint>=1.3.0' 'libwebp' 'aalib' 'mypaint-brushes' 'suitesparse')
 makedepends=('intltool' 'poppler-glib' 'poppler-data' 'alsa-lib' 'iso-codes' 'curl' 'ghostscript' 'gtk-doc' 'glib-networking')
 optdepends=('gutenprint: for sophisticated printing only as gimp has built-in cups print support'
             'poppler-glib: for pdf support'


### PR DESCRIPTION
gimp-devel required libs from **suitesparse** and should be rebuild against new gcc (libfortan bump).

@philmmanjaro  @Ste74  @jonathonf 